### PR TITLE
test: simplify testing publish dir

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -11,3 +11,30 @@ To make that happen, use the following naming conventions that imply a hierarchy
   - Example: `Prepare_Refs`
 - Workflow: UPPER_SNAKE_CASE
   - Example: `PROCESS_READS`
+
+## Testing
+
+Use the [`nf-test`](https://code.askimed.com/nf-test/) framework for testing.
+
+### What to test
+
+Ideally, all processes, subworkflows, workflows, and pipelines should be tested.
+I (Trevor) am a proponent of test-driven (specifically behavior-driven) development, which means most everything will be tested as it is implemented.
+In order to simplify testing, I highly recommend a strategy something like the following:
+
+- Processes
+  - Test processes for a combination of possible inputs to make sure it behaves as expected.
+  - Test that processes emit the expected channels.
+  - Do not test that processes produce expected files in the proper publish directories. This behavior should be tested at the workflow and pipeline levels.
+- Subworkflows
+  - Same recommendations as processes.
+- Workflows
+  - Test workflows for a combination of possible inputs and parameters used in workflows.
+    - If subworkflows or processes can be skipped or behavior relies on parameters (e.g. allowed tools) make sure that it works here.
+  - Test that workflows emit the expected channels.
+  - Test that expected files are produced in the proper publish directories.
+  - This is generally where the most extensive testing should be done - if workflows behave as expected then ideally so will the subworkflows and processes that comprise them as well the pipelines that they comprise.
+- Pipelines
+  - Test that the expected number of tasks succeed.
+  - Test that the pipeline fails if given conditions for which it should fail.
+  - Test tat expected files are produced in the proper publish directories.

--- a/tests/modules/cutadapt.nf.test
+++ b/tests/modules/cutadapt.nf.test
@@ -85,14 +85,6 @@ nextflow_process {
             }
 
             assert snapshot(process.out.reads).match()
-
-            // test trimmed fastq gets published to data directory
-            def fastq = path("${params.publishDirData}/reads/trim/SRR1066657_GSM1299413_WT_NR_A_R1.fastq.gz")
-            assert fastq.exists()
-
-            // test trim log gets published to reports directory
-            def log = path("${params.publishDirReports}/reads/trim/SRR1066657_GSM1299413_WT_NR_A_cutadapt-log.txt")
-            assert log.exists()
         }
 
     }

--- a/tests/modules/fastqc.nf.test
+++ b/tests/modules/fastqc.nf.test
@@ -36,13 +36,6 @@ nextflow_process {
                 assert size() == 1
                 assert get(0) ==~ /^.*\/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000_fastqc.zip/
             }
-
-            // test html files get published to reports directory
-            def html = path("${params.publishDirReports}/fastqc/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000_fastqc.html")
-            assert html.exists()
-            // test zip files get published to reports directory
-            def zip  = path("${params.publishDirReports}/fastqc/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000_fastqc.zip")
-            assert zip.exists()
         }
 
     }
@@ -82,17 +75,6 @@ nextflow_process {
                 assert get(0) ==~ /^.*\/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000_fastqc.zip/
                 assert get(1) ==~ /^.*\/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000_fastqc.zip/
             }
-
-            // test html files get published to reports directory
-            def htmlR1 = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000_fastqc.html")
-            def htmlR2 = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000_fastqc.html")
-            assert htmlR1.exists()
-            assert htmlR2.exists()
-            // test zip files get published to reports directory
-            def zipR1  = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000_fastqc.zip")
-            def zipR2  = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000_fastqc.zip")
-            assert zipR1.exists()
-            assert zipR2.exists()
         }
 
     }

--- a/tests/modules/multiqc.nf.test
+++ b/tests/modules/multiqc.nf.test
@@ -41,13 +41,6 @@ nextflow_process {
                 assert get(5) ==~ /^.*\/multiqc_data\/multiqc_samtools_stats[.]txt/
                 assert get(6) ==~ /^.*\/multiqc_data\/multiqc_sources[.]txt/
             }
-
-            // test html report gets published to reports directory
-            def html    = path("${params.publishDirReports}/multiqc/multiqc/multiqc.html")
-            assert html.exists()
-            // test data files get published to reports directory
-            def dataDir = path("${params.publishDirReports}/multiqc/multiqc/multiqc_data")
-            assert dataDir.exists()
         }
 
     }

--- a/tests/subworkflows/qc_reads_prealign.nf.test
+++ b/tests/subworkflows/qc_reads_prealign.nf.test
@@ -39,19 +39,6 @@ nextflow_workflow {
                 assert get(0) ==~ /^.*\/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000_fastqc.zip/
                 assert get(1) ==~ /^.*\/SAMPLE3_SE.cutadapt.log/
             }
-
-            // test FastQC html files get published to reports directory
-            def html = path("${params.publishDirReports}/fastqc/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000_fastqc.html")
-            assert html.exists()
-            // test FastQC zip files get published to reports directory
-            def zip  = path("${params.publishDirReports}/fastqc/SRR1066657_GSM1299413_WT_NR_A_Saccharomyces_cerevisiae_RNA-Seq_50000_fastqc.zip")
-            assert zip.exists()
-            // test MultiQC html report gets published to reports directory
-            def htmlMQC    = path("${params.publishDirReports}/multiqc/reads_prealign/reads_prealign.html")
-            assert htmlMQC.exists()
-            // test MultiQC data files get published to reports directory
-            def dataDirMQC = path("${params.publishDirReports}/multiqc/reads_prealign/reads_prealign_data")
-            assert dataDirMQC.exists()
         }
 
     }
@@ -93,23 +80,6 @@ nextflow_workflow {
                 assert get(1) ==~ /^.*\/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000_fastqc.zip/
                 assert get(2) ==~ /^.*\/SAMPLE3_SE.cutadapt.log/
             }
-
-            // test FastQC html files get published to reports directory
-            def htmlR1 = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000_fastqc.html")
-            def htmlR2 = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000_fastqc.html")
-            assert htmlR1.exists()
-            assert htmlR2.exists()
-            // test FastQC zip files get published to reports directory
-            def zipR1  = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_1_50000_fastqc.zip")
-            def zipR2  = path("${params.publishDirReports}/fastqc/SRR6924589_GSM3073211_Saccharomyces_cerevisiae-AN_Biological_Repeat-1_Saccharomyces_cerevisiae_RNA-Seq_2_50000_fastqc.zip")
-            assert zipR1.exists()
-            assert zipR2.exists()
-            // test MultiQC html report gets published to reports directory
-            def htmlMQC    = path("${params.publishDirReports}/multiqc/reads_prealign/reads_prealign.html")
-            assert htmlMQC.exists()
-            // test MultiQC data files get published to reports directory
-            def dataDirMQC = path("${params.publishDirReports}/multiqc/reads_prealign/reads_prealign_data")
-            assert dataDirMQC.exists()
         }
 
     }

--- a/tests/subworkflows/trim_reads.nf.test
+++ b/tests/subworkflows/trim_reads.nf.test
@@ -83,14 +83,6 @@ nextflow_workflow {
 
             // test read trimming log
             assert workflow.out.trim_log
-
-            // test trimmed fastq gets published to data directory
-            def fastq = path("${params.publishDirData}/reads/trim/SRR1066657_GSM1299413_WT_NR_A_R1.fastq.gz")
-            assert fastq.exists()
-
-            // test trim log gets published to reports directory
-            def log = path("${params.publishDirReports}/reads/trim/SRR1066657_GSM1299413_WT_NR_A_cutadapt-log.txt")
-            assert log.exists()
         }
 
     }


### PR DESCRIPTION
Testing that files were correctly written to publish dirs at every step and every level made testing very clunky and hard to adapt new test suites. Testing this only at the workflow and pipeline levels should make getting new tests up and going much easier.